### PR TITLE
fix: react hooks and jsx, refactor: parentheses for arrow func parameters

### DIFF
--- a/jsx.js
+++ b/jsx.js
@@ -24,7 +24,7 @@ module.exports = {
 			},
 		],
 		'react/jsx-equals-spacing': [2, 'always'],
-		'react/jsx-filename-extension': [2, { extension: ['.jsx'] }],
+		'react/jsx-filename-extension': [2, { extensions: ['.jsx'] }],
 		'react/jsx-first-prop-new-line': [2, 'never'],
 		'react/jsx-handler-names': 0,
 		'react/jsx-indent': [2, 'tab'],

--- a/react.js
+++ b/react.js
@@ -3,9 +3,10 @@ const path = require('path');
 module.exports = {
 	parserOptions: {
 		jsx: true,
+		sourceType: 'modules',
 	},
 	extends: [
-		'plugin:react-hooks',
+		'plugin:react-hooks/recommended',
 		'plugin:react/recommended',
 		path.join(__dirname, 'jsx.js'),
 		path.join(__dirname, 'index.js'),

--- a/svelte.js
+++ b/svelte.js
@@ -13,6 +13,6 @@ module.exports = {
 		},
 	],
 	settings: {
-		'svelte3/ignore-styles': attributes => attributes.lang,
+		'svelte3/ignore-styles': (attributes) => attributes.lang,
 	},
 };


### PR DESCRIPTION
- Changes the react config to properly extend the react-hooks plugin
- Sets the associated file extensions for JSX properly
- Adds parentheses around parameter in arrow function to conform with prettier rules