### PR TITLE
fix: type in source type for react

### DIFF
--- a/react.js
+++ b/react.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
 	parserOptions: {
 		jsx: true,
-		sourceType: 'modules',
+		sourceType: 'module',
 	},
 	extends: [
 		'plugin:react-hooks/recommended',


### PR DESCRIPTION
In the previous PR I typoed `'module'` as `'modules'`.