### PR TITLE
refactor: all prettier configs have been merged

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	"homepage": "https://github.com/iCrawl/eslint-config-aqua#readme",
 	"devDependencies": {
 		"eslint": "^7.16.0",
-		"eslint-config-prettier": "^7.1.0",
+		"eslint-config-prettier": "^8.0.0",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.21.5",
 		"eslint-plugin-react-hooks": "^4.2.0",

--- a/prettier/jsx.js
+++ b/prettier/jsx.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [path.join(__dirname, '..', 'jsx.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier/react'],
+	extends: [path.join(__dirname, '..', 'jsx.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier'],
 };

--- a/prettier/react.js
+++ b/prettier/react.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [path.join(__dirname, '..', 'react.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier/react'],
+	extends: [path.join(__dirname, '..', 'react.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier'],
 };

--- a/prettier/vue.js
+++ b/prettier/vue.js
@@ -1,5 +1,5 @@
 const path = require('path');
 
 module.exports = {
-	extends: [path.join(__dirname, '..', 'vue.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier/vue'],
+	extends: [path.join(__dirname, '..', 'vue.js'), path.join(__dirname, '..', 'prettier.js'), 'prettier'],
 };


### PR DESCRIPTION
This PR refactors all usage of all declared prettier configs as they've been merged into one with `eslint-config-prettier` v8.

ref: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
